### PR TITLE
Fix pyproject.toml project name mismatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "timer"
+name = "timekid"
 version = "0.1.0"
 description = "timekid - High-precision timing and profiling library for Python."
 readme = "README.md"


### PR DESCRIPTION
Fixes project metadata name mismatch in `pyproject.toml` (`timer` -> `timekid`).

Closes #6