### PR TITLE
Make benchmark warmup count configurable

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Peter Vestereng Larsen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/timekid/timer.py
+++ b/src/timekid/timer.py
@@ -378,11 +378,12 @@ class Timer:
             func(*args, **kwargs)
         return ctx
     
-    def benchmark(self, func: Callable[P, R], num_iter: int,
+    def benchmark(self, func: Callable[P, R], num_iter: int, warmup: int = 1,
                   *args: P.args, **kwargs: P.kwargs) -> list[TimerContext]:
         # Benchmark runs anonymously and doesn't persist in registry
-        # Single warmup run to handle JIT compilation or lazy initialization
-        func(*args, **kwargs)
+        # Warmup runs to handle JIT compilation or lazy initialization
+        for _ in range(warmup):
+            func(*args, **kwargs)
 
         str_key: str = f"{func.__name__} benchmark"
         results: list[TimerContext] = []


### PR DESCRIPTION
Adds `warmup: int = 1` parameter to `Timer.benchmark()` and runs warmup loop accordingly (`0` means no warmup).

Closes #8