### PR TITLE
Add context manager support to StopWatch

### DIFF
--- a/src/timekid/timer.py
+++ b/src/timekid/timer.py
@@ -97,7 +97,19 @@ class StopWatch(BaseTimer):
         self._end_time = None
         self._elapsed_time = None
         self._status = Status.PENDING
-        
+
+    def __enter__(self) -> Self:
+        self.start()
+        return self
+
+    def __exit__(self,
+                 exc_type: Optional[Type[BaseException]],
+                 exc_value: Optional[BaseException],
+                 traceback: Optional[TracebackType]) -> None:
+        self.stop()
+        if exc_type is not None:
+            self._status = Status.FAILED
+
     def __repr__(self) -> str:
         parts = [f'status={self.status}']
         if self._start_time is not None:

--- a/tests/_basic_test.py
+++ b/tests/_basic_test.py
@@ -177,6 +177,24 @@ class TestStopWatch(unittest.TestCase):
         self.assertIn("elapsed_time=", repr_str)
         self.assertIn("status=stopped", repr_str)
 
+    def test_context_manager_success(self):
+        """Test StopWatch context manager successful execution."""
+        with StopWatch(precision=2) as sw:
+            time.sleep(0.1)
+
+        self.assertEqual(sw.status, Status.STOPPED)
+        self.assertAlmostEqual(sw.elapsed_time, 0.1, places=1)
+
+    def test_context_manager_exception_sets_failed(self):
+        """Test StopWatch context manager marks FAILED on exception."""
+        sw = None
+        with self.assertRaises(ValueError):
+            with StopWatch(precision=2) as sw:
+                raise ValueError("boom")
+
+        assert sw is not None
+        self.assertEqual(sw.status, Status.FAILED)
+
 
 class TestTimer(unittest.TestCase):
     def test_registry(self):


### PR DESCRIPTION
Adds `__enter__`/`__exit__` to `StopWatch`:
- `__enter__` calls `start()` and returns `self`
- `__exit__` calls `stop()`
- on exception, status is set to `FAILED`

Also adds basic tests for successful and exception context-manager usage.

Closes #9