### PR TITLE
Add license field to pyproject.toml project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "timekid"
 version = "0.1.0"
+license = "MIT"
 description = "timekid - High-precision timing and profiling library for Python."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Fixes #19

Adds `license = "MIT"` to the `[project]` section of `pyproject.toml` to match the existing MIT `LICENSE` file and improve package metadata for tooling/indexes.