### PR TITLE
Default verbose timer output to logging instead of print

### DIFF
--- a/src/timekid/timer.py
+++ b/src/timekid/timer.py
@@ -1,4 +1,5 @@
 import time
+import logging
 from types import TracebackType
 from typing import (Self, Type, Optional, Callable, Generator,
                     Awaitable, AsyncGenerator, ParamSpec, TypeVar)
@@ -10,6 +11,8 @@ __author__ = "Peter Vestereng Larsen"
 __version__ = "0.1.0"
 __license__ = "MIT"
 __email__ = "p.vesterenglarsen@gmail.com"
+
+logger = logging.getLogger('timekid')
 
 P = ParamSpec(name='P')
 P_async = ParamSpec(name='P_async')
@@ -124,7 +127,7 @@ class TimerContext(BaseTimer):
     While TimerContext can be used directly, the recommended approach is to access it via the Timer class (e.g., `timer["my_key"]`).
     """
     def __init__(self, precision: Optional[int], name: Optional[str] = None, verbose: bool = False,
-                 log_func: Callable[[str], None] = print) -> None:
+                 log_func: Callable[[str], None] = logger.info) -> None:
         self._name: str = str(name) if name is not None else 'Unnamed'
         self._precision = precision
         self._elapsed_time: Optional[float] = None
@@ -227,7 +230,7 @@ class TimerContext(BaseTimer):
 
 class Timer:
     def __init__(self, precision: Optional[int] = None, verbose: bool = False,
-                 log_func: Callable[[str], None] = print) -> None:
+                 log_func: Callable[[str], None] = logger.info) -> None:
         self._precision = precision
         self._verbose = verbose
         self._log_func = log_func
@@ -344,7 +347,7 @@ class Timer:
         return self._registry.get(key, [])
     
     @contextmanager
-    def anonymous(self, name: Optional[str] = None, verbose: bool = False, log_func: Callable[[str], None] = print) -> Generator[TimerContext, None, None]:
+    def anonymous(self, name: Optional[str] = None, verbose: bool = False, log_func: Callable[[str], None] = logger.info) -> Generator[TimerContext, None, None]:
         with TimerContext(self.precision, name=name, verbose=verbose, log_func=log_func) as ctx:
             yield ctx
             


### PR DESCRIPTION
Fixes #18

Changes verbose-mode default logging behavior in `src/timekid/timer.py`:
- adds `import logging`
- adds module-level logger: `logger = logging.getLogger("timekid")`
- changes default `log_func` from `print` to `logger.info` in:
  - `TimerContext.__init__`
  - `Timer.__init__`
  - `Timer.anonymous()`

`_noop` behavior for `verbose=False` remains unchanged.