### PR TITLE
Add FastTimer low-overhead API (pure Python scaffold)

### DIFF
--- a/ISSUE_DRAFT_submicro.md
+++ b/ISSUE_DRAFT_submicro.md
@@ -1,0 +1,28 @@
+# Issue draft: Sub-microsecond / lower-overhead measurement mode
+
+## Motivation
+Timekid aims to be a "gold standard" timing/performance evaluation library.
+For very small code paths (microsecond and below), Python overhead (context manager, object creation, dict lookup, list append, wrapper calls) can dominate the measurement and distort results.
+
+## Proposal
+Add a low-overhead API surface (and eventual native backend) optimized for high-volume measurements:
+
+- A `FastTimer` that stores raw integer nanoseconds internally.
+- Optional `key_id("name") -> int` to do string hashing/dict work once.
+- `start(key) -> token` / `stop(token) -> elapsed_ns` hot path.
+- Convert to seconds + rounding only at reporting time.
+
+## Notes on precision
+- Python already exposes `time.perf_counter_ns()` (ns units, not necessarily ns *accuracy*).
+- On modern Linux/macOS/Windows, accuracy is usually in the 10s–100s of ns to a few microseconds depending on platform.
+- For honest runtimes, the key is lowering *observer overhead* more than chasing nominal ns.
+
+## Future (optional)
+- Rust backend via PyO3 + maturin:
+  - store deltas in `Vec<u64>` per key
+  - bulk-export results to Python
+  - optional ring buffer mode
+
+## Acceptance criteria
+- Demonstrate reduced overhead in a microbenchmark vs the current `Timer` context-manager path.
+- Maintain pure-Python fallback.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,27 @@ pip install -e .
 
 ## Quick Start
 
+### Low-overhead timing (FastTimer)
+
+If you need minimal overhead and are doing a large number of measurements, use `FastTimer`.
+It stores raw integer nanoseconds internally and only converts to seconds when you report.
+
+```python
+from timekid.fast import FastTimer
+
+ft = FastTimer()
+key = ft.key_id("hot_loop")  # do string->id once
+
+for _ in range(1000):
+    tok = ft.start(key)
+    # ... hot code ...
+    ft.stop(tok)
+
+print(ft.times_s(precision=6)[key][:5])
+```
+
+(Planned) a future optional Rust backend can implement the same API for even lower overhead.
+
 ### Basic Timing with Context Manager
 
 ```python

--- a/src/timekid/__init__.py
+++ b/src/timekid/__init__.py
@@ -1,7 +1,11 @@
 """timekid - High-precision timing and profiling library for Python."""
 
 from .timer import Timer, StopWatch, TimerContext, Status
+from .fast import FastTimer, Token
 
-__all__ = ['Timer', 'StopWatch', 'TimerContext', 'Status']
+__all__ = [
+    'Timer', 'StopWatch', 'TimerContext', 'Status',
+    'FastTimer', 'Token',
+]
 __version__ = '0.1.0'
 __author__ = 'Peter Vestereng Larsen'

--- a/src/timekid/fast.py
+++ b/src/timekid/fast.py
@@ -1,0 +1,112 @@
+"""timekid.fast
+
+A low-overhead timing backend-oriented API.
+
+Design goals:
+- Minimize Python overhead in the hot path.
+- Store raw integer nanoseconds internally; convert/round only at reporting time.
+- Provide a stable Python API with an optional native (Rust) accelerator.
+
+The initial implementation is pure Python and intentionally minimal.
+A future Rust backend can implement the same protocol.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Dict, List, Union
+import time
+
+Key = Union[str, int]
+
+
+@dataclass(frozen=True, slots=True)
+class Token:
+    """Opaque handle returned by start()."""
+
+    key: Key
+    t0_ns: int
+
+
+class FastTimer:
+    """Low-overhead timer intended for *lots* of measurements.
+
+    Typical usage:
+
+        ft = FastTimer()
+        key = ft.key_id("db")
+        tok = ft.start(key)
+        ...
+        ft.stop(tok)
+
+    Notes:
+    - For lowest overhead, prefer integer key ids via key_id().
+    - Results are stored as raw nanoseconds in-memory.
+    """
+
+    __slots__ = ("_key_map", "_next_key", "_times_ns")
+
+    def __init__(self) -> None:
+        self._key_map: Dict[str, int] = {}
+        self._next_key: int = 0
+        self._times_ns: Dict[Key, List[int]] = {}
+
+    def key_id(self, name: str) -> int:
+        """Return a stable integer id for a key name.
+
+        Use this once up-front, then pass the id (int) to start().
+        """
+
+        try:
+            return self._key_map[name]
+        except KeyError:
+            kid = self._next_key
+            self._next_key += 1
+            self._key_map[name] = kid
+            return kid
+
+    def start(self, key: Key) -> Token:
+        """Start timing and return a Token."""
+
+        return Token(key=key, t0_ns=time.perf_counter_ns())
+
+    def stop(self, token: Token) -> int:
+        """Stop timing for a given token and record the elapsed time.
+
+        Returns:
+            elapsed_ns: int
+        """
+
+        dt = time.perf_counter_ns() - token.t0_ns
+        self._times_ns.setdefault(token.key, []).append(dt)
+        return dt
+
+    def clear(self, key: Optional[Key] = None) -> None:
+        """Clear recorded measurements."""
+
+        if key is None:
+            self._times_ns.clear()
+        else:
+            self._times_ns.pop(key, None)
+
+    @property
+    def times_ns(self) -> Dict[Key, List[int]]:
+        """Raw nanosecond timings (no rounding)."""
+
+        # Return a shallow copy to avoid accidental external mutation.
+        return {k: list(v) for k, v in self._times_ns.items()}
+
+    def times_s(self, *, precision: Optional[int] = None) -> Dict[Key, List[float]]:
+        """Return timings in seconds.
+
+        Args:
+            precision: if set, round to this many decimal places.
+        """
+
+        out: Dict[Key, List[float]] = {}
+        for k, arr in self._times_ns.items():
+            vals = [ns / 1e9 for ns in arr]
+            if precision is not None:
+                vals = [round(x, precision) for x in vals]
+            out[k] = vals
+        return out

--- a/tests/fast_test.py
+++ b/tests/fast_test.py
@@ -1,0 +1,41 @@
+import time
+import unittest
+
+from timekid.fast import FastTimer
+
+
+class TestFastTimer(unittest.TestCase):
+    def test_start_stop_records(self):
+        ft = FastTimer()
+        tok = ft.start("x")
+        time.sleep(0.01)
+        dt = ft.stop(tok)
+
+        self.assertIsInstance(dt, int)
+        self.assertGreater(dt, 0)
+        self.assertIn("x", ft.times_ns)
+        self.assertEqual(len(ft.times_ns["x"]), 1)
+
+    def test_key_id_is_stable(self):
+        ft = FastTimer()
+        a1 = ft.key_id("a")
+        a2 = ft.key_id("a")
+        b = ft.key_id("b")
+        self.assertEqual(a1, a2)
+        self.assertNotEqual(a1, b)
+
+    def test_times_s_precision(self):
+        ft = FastTimer()
+        tok = ft.start("x")
+        time.sleep(0.012345)
+        ft.stop(tok)
+        out = ft.times_s(precision=3)
+        self.assertIn("x", out)
+        self.assertEqual(len(out["x"]), 1)
+        # Rounded to 3 decimal places => string repr has <=3 dp
+        s = f"{out['x'][0]:.3f}"
+        self.assertRegex(s, r"^\d+\.\d{3}$")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a new low-overhead timing API (FastTimer) intended for high-volume measurements.

Related issue: https://github.com/pvl-clawbot/timekid/issues/26
